### PR TITLE
Add more JS plugins

### DIFF
--- a/docs/javascript/plugins.md
+++ b/docs/javascript/plugins.md
@@ -2,20 +2,77 @@
 
 ## Almost always used
 
-- ssb-db
-- ssb-master
 - ssb-backlinks
-- ssb-query
+- ssb-blobs
+- ssb-db
 - ssb-friends
+- ssb-gossip
+- ssb-logging
+- ssb-master
+- ssb-no-auth
+- ssb-query
 - ssb-replicate
-- ...
+- ssb-unix-socket
 
 ## Often used
 
+- ssb-about
 - ssb-conn
 - ssb-ebt
-- ...
+- ssb-lan
+- ssb-links
+- ssb-local
+- ssb-onion
+- ssb-ooo
+- ssb-plugins
+- ssb-private
+- ssb-search
+- ssb-suggest
+- ssb-ws
 
+## Sometimes used
+
+- ssb-blobs-purge
+- ssb-contacts
+- ssb-device-address
+- ssb-dht-invite
+- ssb-friend-pub
+- ssb-identities
+- ssb-incoming-guard
+- ssb-invite-client
+- ssb-meme
+- ssb-names
+- ssb-notifier
+- ssb-peer-invites
+- ssb-private-groups
+- ssb-publishguard
+- ssb-room
+- ssb-serve-blobs
+- ssb-server-channel
+- ssb-tags
+- ssb-threads
+- ssb-unread
+
+## Application-specific
+
+- git-ssb-web
+- patchfoo
+- smtp-ssb
+- ssb-activity
+- ssb-autoname
+- ssb-chess-db
+- ssb-dns
+- ssb-ebt-and-onboarding-only
+- ssb-ebt-fork-staltz
+- ssb-exec
+- ssb-gitindex
+- ssb-invites-store
+- ssb-npm-registry
+- ssb-repl
+- ssb-server-ticktack
+- ssb-talequery
+- ssb-viewer
 
 ## Deprecated
 
+- ssb-fulltext


### PR DESCRIPTION
This adds more SSB JS plugins to the list.

For discovery of plugins, I referred to this old table of plugins:
[https://viewer.scuttlebot.io/&l3Xs7I+pnjnwinaBWVvkw5kaAchm/W/B3y+YiGLUGLY=.sha256](table.html)
([Thread](https://viewer.scuttlebot.io/%25wGgP3og6knIB75LinEPMeOagTJc5GJtfQFLdfQmVHH8%3D.sha256)) and the latest source code of some of the plugins mentioned therein, and memory.

I added categories "Sometimes used" and "Application-specific" to the list, and alphabetized entries in the lists.

The categorization is fairly arbitrary. "Application-specific" includes both plugins meant for specific applications (e.g. ssb-chess-db) as well as applications themselves which are ssb-server plugins (e.g. ssb-viewer).

I did not find any plugins declared deprecated by their author/maintainer. The only one I added to the "Deprecated" list was `ssb-fulltext` as I authored it - but even then I only just now because of this actually marked it as deprecated in its repo. Likely some of the ones listed are no longer actively used but are still used in some app - how used that is which is another question. There are also are probably other useful plugins not listed here which I am not aware of or am forgetting.