### PR TITLE
Add basic documentation for the Sunrise Choir Rust implementation

### DIFF
--- a/docs/rust/sunrise-choir.md
+++ b/docs/rust/sunrise-choir.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The code for the Sunrise Choir Rust SSB implementation is split between many repositories which can be found on their [GitHub organization page](https://github.com/sunrise-choir). Further information about the team and their work can be found on the [Sunrise Choir website](https://sunrisechoir.com/) or [OpenCollective page](https://opencollective.com/sunrise-choir).
+The code for the Sunrise Choir Rust SSB implementation is split between many repositories which can be found on their [GitHub organization page](https://github.com/sunrise-choir). Many of the crates have excellent low-level documentation in the form of HTML pages generated from documentation comments in the source code. Links for crate-specific documentation can usually be found in the crate repository READMEs. Further information about the team and their work can be found on the [Sunrise Choir website](https://sunrisechoir.com/) or [OpenCollective page](https://opencollective.com/sunrise-choir).
 
 If you are not familiar with the [Rust programming language](https://www.rust-lang.org/), please visit the [Getting started](https://www.rust-lang.org/learn/get-started) page to learn more. The [Rust programming language book](https://doc.rust-lang.org/book/) and [Rust By Example](https://doc.rust-lang.org/stable/rust-by-example/) are both excellent learning guides.
 
@@ -63,5 +63,57 @@ let signature = aruna.sign(&example_string.as_bytes());
 println!("{:?}", signature.as_base64());
 // "o5w5E3Kt2AmJlwx4mocLz4V622m5Y0C3jirs1xTDoHdxvAXbfZMMJ7PfEE5ZV6eLWpI3HyhtmiqyUlRuMSZsBw=="
 
-// notice that the output does not include a ".ed25519" suffix or a sigil prefix
+// note: notice that the output does not include a ".ed25519" suffix or a sigil prefix
 ```
+
+### Verification
+
+Now when we compare the signature against Aruna's public key, we'll see that the signature is valid and that Aruna must have signed this message. This is important for ensuring that an object hasn't been tampered with. Any change to the object will invalidate the signature.
+
+```rust
+let is_valid = aruna.public.verify(&signature, &example_string.as_bytes());
+
+println!("{}", is_valid);
+// true
+```
+
+If we try to do the same verification with Benedict's public key, we'll see that the signature is **not valid**. Either the public key is incorrect or the object has been tampered with, but the signature is invalid.
+
+```rust
+let is_valid = benedict.public.verify(&signature, &example_string.as_bytes());
+
+println!("{}", is_valid);
+// false
+```
+
+## Cryptography
+
+The object signing illustrated above is made possible by the [ssb_crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) crate:
+
+> This crate provides the cryptographic functionality needed to implement the Secure Scuttlebutt networking protocols and content signing and encryption.
+
+> There are two implementations of the crypto operations available; one that uses [libsodium](https://libsodium.gitbook.io/) C library (via the [sodiumoxide](https://crates.io/crates/sodiumoxide) crate), and a pure-rust implementation that uses [dalek](https://dalek.rs/) and [RustCrypto](https://github.com/RustCrypto/) crates (which is the default). You can select which implementation to use via Cargo.toml feature flags (see documentation - link above).
+
+### Verification
+
+The [ssb-verify-signatures](https://github.com/sunrise-choir/ssb-verify-signatures) crate allows us to verify the signature of an entire SSB message. It also allows the verification of multiple messages in parallel.
+
+```rust
+// let is_verified = verify_message(&msg).is_ok();
+```
+
+### Validation
+
+```rust
+// let is_valid = validate_message_hash_chain::<_, &[u8]>(&msg, None).is_ok();
+```
+
+## Contact
+
+The Sunrise Choir consists of [@Mikey](https://github.com/ahdinosaur), [@Piet](https://github.com/pietgeursen), [@Matt](https://github.com/mmckegg) and [@Sean](https://github.com/sbillig). This documentation was compiled by [@glyph](https://github.com/mycognosist). All can be found in the Scuttleverse:
+
+* mikey: `@6ilZq3kN0F+dXFHAPjAwMm87JEb/VdB+LC9eIMW3sa0=.ed25519`
+* piet: `@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519`
+* matt: `@FbGoHeEcePDG3Evemrc+hm+S77cXKf8BRQgkYinJggg=.ed25519`
+* sean: `@N/vWpVVdD1e8IbACUQE4EVGL6+aodQfbQZ8ByC+k79s=.ed25519`
+* glyph: `@HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=.ed25519`

--- a/docs/rust/sunrise-choir.md
+++ b/docs/rust/sunrise-choir.md
@@ -344,7 +344,7 @@ The [ssb-crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) crate p
 use ssb_crypto::NetworkKey;
 ```
 
-We'll use the most common app key, implemented as a `const` for `NetworkKey`, which is used for the offline-first social network that might be familiar with.
+We'll use the most common app key, implemented as a `const` for `NetworkKey`, which is used for the offline-first social network that you might be familiar with.
 
 ```rust
 let netkey = NetworkKey::SSB_MAIN_NET;
@@ -375,17 +375,26 @@ The Sunrise Choir implementation does not define discovery mechanisms or peer ad
 
 ### Secret Handshake
 
-Once we have discovered the necessary details of our peer (IP address, port, public key), we can create a TCP stream between us and perform the handshake - a 4-step process to authenticate both parties and establish an encrypted channel. In the Sunrise Choir SSB implementation, the [ssb-handshake](https://github.com/sunrise-choir/ssb-handshake) crate provides us with the necessary functionality. The crate provides two primary functions: one for the [`server_side()`](https://docs.rs/ssb-handshake/0.5.1/ssb_handshake/fn.server_side.html) of the handshake and one for the [`client_side()`](https://docs.rs/ssb-handshake/0.5.1/ssb_handshake/fn.client_side.html).
+Once we have discovered the necessary details of our peer (IP address, port, public key), we can create a TCP stream between us and perform the handshake: a 4-step process to authenticate both parties and establish an encrypted channel. In the Sunrise Choir SSB implementation, the [ssb-handshake](https://github.com/sunrise-choir/ssb-handshake) crate provides us with the necessary functionality. The crate provides two primary functions: one for the [`server_side()`](https://docs.rs/ssb-handshake/0.5.1/ssb_handshake/fn.server_side.html) of the handshake and one for the [`client_side()`](https://docs.rs/ssb-handshake/0.5.1/ssb_handshake/fn.client_side.html).
 
 ```rust
-let ip_addr = ;
-let port: u16 = 45982;
-
-let listener = TcpListener::bind(hs_listener_socket_addr)?;
-
-let server_side = ssb_handshake::server_side(&mut s_stream, &net_key, &skey);
+// initiate the server side of the handshake
+let handshake_keys = ssb_handshake::server_side(&mut stream, &net_key, &server_keypair).await?;
 ```
-// https://github.com/clevinson/scuttle-chat/blob/master/src/peer_manager.rs
+
+Note that we need to know the public key of the server we are attempting to authenticate with. 
+
+```rust
+// initiate the client side of the handshake
+let handshake_keys = ssb_handshake::client_side(&mut stream, &net_key, &client_keypair, &server_pk).await?;
+```
+
+Working code examples for these methods (using [`async_std`](https://docs.rs/async-std/1.9.0/async_std/)) can be found in the Sunrise SSB Playground: [`async_server_handshake.rs`](https://github.com/mycognosist/sunrise-ssb-playground/blob/main/examples/async_server_handshake.rs) and [`async_client_handshake`](https://github.com/mycognosist/sunrise-ssb-playground/blob/main/examples/async_client_handshake.rs).
+
+## TODO
+
+Box stream: https://github.com/sunrise-choir/ssb-boxstream
+Packet stream: https://github.com/sunrise-choir/ssb-packetstream
 
 ## Contact
 

--- a/docs/rust/sunrise-choir.md
+++ b/docs/rust/sunrise-choir.md
@@ -96,7 +96,7 @@ The object signing illustrated above is made possible by the [ssb_crypto](https:
 
 ### Verification
 
-A valid signature isn't the only constraint that SSB messages have to meet. The [ssb-verify-signatures](https://github.com/sunrise-choir/ssb-verify-signatures) crate allows us to verify the signature of an entire SSB message. It also allows the verification of multiple messages in parallel.
+The [ssb-verify-signatures](https://github.com/sunrise-choir/ssb-verify-signatures) crate allows us to verify the signature of an entire SSB message. It also allows the verification of multiple messages in parallel.
 
 Let's first attempt to verify a message we know to be invalid. This message contains a `key` field and nothing else.
 
@@ -196,7 +196,7 @@ The batch processing methods will return an error (`Err(InvalidSignature)`) if t
 
 ### Validation
 
-A valid signature isn't the only constraint that SSB messages have to meet. The [ssb-validate](https://github.com/sunrise-choir/ssb-validate) crate helps us create and verify messages to ensure that they conform to the [message format](https://ssbc.github.io/scuttlebutt-protocol-guide/#message-format).
+A valid signature isn't the only constraint that SSB messages have to meet. The [ssb-validate](https://github.com/sunrise-choir/ssb-validate) crate helps us to verify that messages conform to the [message format](https://ssbc.github.io/scuttlebutt-protocol-guide/#message-format).
 
 ```rust
 use ssb_validate;

--- a/docs/rust/sunrise-choir.md
+++ b/docs/rust/sunrise-choir.md
@@ -294,8 +294,6 @@ match ssb_validate::par_validate_message_hash_chain_of_feed::<_, &[u8]>(&message
 // validated
 ```
 
------
-
 ## SSB Multiformats
 
 You may have noticed that entities in SSB are referenced with a string starting with a sigil:

--- a/docs/rust/sunrise-choir.md
+++ b/docs/rust/sunrise-choir.md
@@ -8,7 +8,7 @@ If you are not familiar with the [Rust programming language](https://www.rust-la
 
 ## SSB-Keyfile
 
-[SSB-Keyfile](https://github.com/sunrise-choir/ssb-keyfile) provides basic utilities to create and read keyfiles that are compatible with the JS SSB implementation. This module reexports the [`Keypair` struct](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.Keypair.html) and related methods from the [ssb-crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) module.
+[SSB-Keyfile](https://github.com/sunrise-choir/ssb-keyfile) provides basic utilities to create and read keyfiles that are compatible with the JS SSB implementation. This module reexports the [`Keypair` struct](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.Keypair.html) and related methods from the [ssb-crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) module. As with most of the Sunrise Choir Rust SSB modules, SSB-Keyfile can either be imported into another project as a library or compiled into a standalone binary which takes parameters as arguments.
 
 ```rust
 use ssb_keyfile::Keypair;
@@ -44,4 +44,24 @@ println!("{:#?}", benedict);
 let benedict = ssb_keyfile::read_from_path("/home/benedict/.ssb/secret")?;
 ```
 
-TODO
+### Signing
+
+The most common operation with our keys is signing objects and then verifying their signatures. SSB has a very specific message encoding format, but for this example we'll use an example object.
+
+```rust
+// create an example object with json encoding (using serde_json)
+let example_object = json!({ "type": "example" });
+```
+
+We'll use Aruna's private key to sign this object. Since the `keypair.sign()` method takes a byte slice, we convert the JSON object to a `String` and then a byte slice (`[u8]`).
+
+```rust
+let example_string = example_object.to_string();
+
+let signature = aruna.sign(&example_string.as_bytes());
+
+println!("{:?}", signature.as_base64());
+// "o5w5E3Kt2AmJlwx4mocLz4V622m5Y0C3jirs1xTDoHdxvAXbfZMMJ7PfEE5ZV6eLWpI3HyhtmiqyUlRuMSZsBw=="
+
+// notice that the output does not include a ".ed25519" suffix or a sigil prefix
+```

--- a/docs/rust/sunrise-choir.md
+++ b/docs/rust/sunrise-choir.md
@@ -10,7 +10,7 @@ A playground repository exists as a partner reference to this document: [Sunrise
 
 ## SSB-Keyfile
 
-[SSB-Keyfile](https://github.com/sunrise-choir/ssb-keyfile) provides basic utilities to create and read keyfiles that are compatible with the JS SSB implementation. This module reexports the [`Keypair` struct](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.Keypair.html) and related methods from the [ssb-crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) module. As with most of the Sunrise Choir Rust SSB modules, SSB-Keyfile can either be imported into another project as a library or compiled into a standalone binary which takes parameters as arguments.
+[SSB-Keyfile](https://crates.io/crates/ssb-keyfile) provides basic utilities to create and read keyfiles that are compatible with the JS SSB implementation. This module reexports the [`Keypair` struct](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.Keypair.html) and related methods from the [ssb-crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) module. As with most of the Sunrise Choir Rust SSB modules, SSB-Keyfile can either be imported into another project as a library or compiled into a standalone binary which takes parameters as arguments.
 
 ```rust
 use ssb_keyfile::Keypair;
@@ -90,7 +90,7 @@ println!("{}", is_valid);
 
 ## Cryptography
 
-The object signing illustrated above is made possible by the [ssb_crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) crate:
+The object signing illustrated above is made possible by the [ssb-crypto](https://crates.io/crates/ssb-crypto) crate:
 
 > This crate provides the cryptographic functionality needed to implement the Secure Scuttlebutt networking protocols and content signing and encryption.
 
@@ -98,7 +98,7 @@ The object signing illustrated above is made possible by the [ssb_crypto](https:
 
 ### Verification
 
-The [ssb-verify-signatures](https://github.com/sunrise-choir/ssb-verify-signatures) crate allows us to verify the signature of an entire SSB message. It also allows the verification of multiple messages in parallel.
+The [ssb-verify-signatures](https://crates.io/crates/ssb-verify-signatures) crate allows us to verify the signature of an entire SSB message. It also allows the verification of multiple messages in parallel.
 
 Let's first attempt to verify a message we know to be invalid. This message contains a `key` field and nothing else.
 
@@ -198,7 +198,7 @@ The batch processing methods will return an error (`Err(InvalidSignature)`) if t
 
 ### Validation
 
-A valid signature isn't the only constraint that SSB messages have to meet. The [ssb-validate](https://github.com/sunrise-choir/ssb-validate) crate helps us to verify that messages conform to the [message format](https://ssbc.github.io/scuttlebutt-protocol-guide/#message-format).
+A valid signature isn't the only constraint that SSB messages have to meet. The [ssb-validate](https://crates.io/crates/ssb-validate) crate helps us to verify that messages conform to the [message format](https://ssbc.github.io/scuttlebutt-protocol-guide/#message-format).
 
 ```rust
 use ssb_validate;
@@ -302,7 +302,7 @@ You may have noticed that entities in SSB are referenced with a string starting 
 - **`&`** -- Blob
 - **`@`** -- Feed
 
-This is followed by a base64-encoded integer and a suffix that describes what kind of data this is. We _could_ write gourmet parsers for this every time we need to parse an SSB reference, but it's so common that we have a crate which offers a solution for this exact problem: [ssb-multiformats](https://github.com/sunrise-choir/ssb-multiformats).
+This is followed by a base64-encoded integer and a suffix that describes what kind of data this is. We _could_ write gourmet parsers for this every time we need to parse an SSB reference, but it's so common that we have a crate which offers a solution for this exact problem: [ssb-multiformats](https://crates.io/crates/ssb-multiformats).
 
 ```rust
 use ssb_multiformats::multifeed::Multifeed;
@@ -336,7 +336,7 @@ We've got our keypair, we know how to make messages, our feed seems to be valid 
 
 The 'network key' - also known as the 'network identifier', 'app key' or 'SHS key' - is used during the [secret handshake](https://ssbc.github.io/scuttlebutt-protocol-guide/#handshake) to prove that both parties are participating in the same SSB network. It is a 32-byte key which allows distinct, isolated Scuttlebutt networks to be created. If you're building a network of temperature sensors on Secure Scuttlebutt you probably don't want to be peering with people sharing source code or building a social network (👋). In that case, you would supply a unique network key when performing a handshake.
 
-The [ssb-crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) crate provides us with a [`NetworkKey struct`](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.NetworkKey.html) with convenient methods for working with network keys.
+The [ssb-crypto](https://crates.io/crates/ssb-crypto) crate provides us with a [`NetworkKey struct`](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.NetworkKey.html) with convenient methods for working with network keys.
 
 ```rust
 use ssb_crypto::NetworkKey;
@@ -373,7 +373,7 @@ The Sunrise Choir implementation does not define discovery mechanisms or peer ad
 
 ### Secret Handshake
 
-Once we have discovered the necessary details of our peer (IP address, port, public key), we can create a TCP stream between us and perform the handshake: a 4-step process to authenticate both parties and establish an encrypted channel. In the Sunrise Choir SSB implementation, the [ssb-handshake](https://github.com/sunrise-choir/ssb-handshake) crate provides us with the necessary functionality. The crate provides two primary functions: one for the [`server_side()`](https://docs.rs/ssb-handshake/0.5.1/ssb_handshake/fn.server_side.html) of the handshake and one for the [`client_side()`](https://docs.rs/ssb-handshake/0.5.1/ssb_handshake/fn.client_side.html).
+Once we have discovered the necessary details of our peer (IP address, port, public key), we can create a TCP stream between us and perform the handshake: a 4-step process to authenticate both parties and establish an encrypted channel. In the Sunrise Choir SSB implementation, the [ssb-handshake](https://crates.io/crates/ssb-handshake) crate provides us with the necessary functionality. The crate provides two primary functions: one for the [`server_side()`](https://docs.rs/ssb-handshake/0.5.1/ssb_handshake/fn.server_side.html) of the handshake and one for the [`client_side()`](https://docs.rs/ssb-handshake/0.5.1/ssb_handshake/fn.client_side.html).
 
 ```rust
 // initiate the server side of the handshake

--- a/docs/rust/sunrise-choir.md
+++ b/docs/rust/sunrise-choir.md
@@ -1,5 +1,47 @@
 # Sunrise Choir Rust SSB implementation
 
-https://github.com/sunrise-choir
+## Introduction
+
+The code for the Sunrise Choir Rust SSB implementation is split between many repositories which can be found on their [GitHub organization page](https://github.com/sunrise-choir). Further information about the team and their work can be found on the [Sunrise Choir website](https://sunrisechoir.com/) or [OpenCollective page](https://opencollective.com/sunrise-choir).
+
+If you are not familiar with the [Rust programming language](https://www.rust-lang.org/), please visit the [Getting started](https://www.rust-lang.org/learn/get-started) page to learn more. The [Rust programming language book](https://doc.rust-lang.org/book/) and [Rust By Example](https://doc.rust-lang.org/stable/rust-by-example/) are both excellent learning guides.
+
+## SSB-Keyfile
+
+[SSB-Keyfile](https://github.com/sunrise-choir/ssb-keyfile) provides basic utilities to create and read keyfiles that are compatible with the JS SSB implementation. This module reexports the [`Keypair` struct](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.Keypair.html) and related methods from the [ssb-crypto](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/index.html) module.
+
+```rust
+use ssb_keyfile::Keypair;
+```
+
+The most basic operation is generating keys: this produces an identity encoded as a `struct` with two fields: `public` (of type [`PublicKey`](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.PublicKey.html)) and `secret` (of type [`SecretKey`](https://docs.rs/ssb-crypto/0.2.2/ssb_crypto/struct.SecretKey.html)). We'll call this identity **Aruna**.
+
+```rust
+let aruna = Keypair::generate();
+
+println!("{}", aruna.as_base64());
+// vS8uDOK1nU+y3Oxskhfta7AzjbNQ70IpFyoVpzH/IPCzA2COB7U1s7c7NE/2DPjcky67YgZHInOhNWtmqnXVrw==
+
+println!("{}", aruna.public.as_base64());
+// swNgjge1NbO3OzRP9gz43JMuu2IGRyJzoTVrZqp11a8=
+```
+
+Alternatively, we can load or create a key that's saved in a file. These methods allow compatibility with keyfiles conforming to the Javascript implementation. We'll call this identity **Benedict**.
+
+```rust
+use ssb_keyfile::{Keypair, KeyFileError};
+
+// create a keypair and write to file at the given path
+let benedict = ssb_keyfile::generate_at_path("/home/benedict/.ssb/secret")?;
+
+println!("{:#?}", benedict);
+// Keypair {
+//     secret: SecretKey([90, 172, 77, 159, 123, 231, 130, 138, 234, 241, 16, 19, 155, 252, 232, 137, 180, 246, 152, 184, 239, 94, 140, 159, 86, 167, 124, 145, 105, 158, 129, 253]),
+//     public: PublicKey([28, 74, 178, 247, 141, 19, 234, 224, 126, 79, 231, 125, 37, 166, 185, 241, 163, 95, 71, 50, 241, 245, 228, 86, 170, 70, 101, 140, 25, 167, 146, 105])
+// }
+
+// read a keypair from file
+let benedict = ssb_keyfile::read_from_path("/home/benedict/.ssb/secret")?;
+```
 
 TODO


### PR DESCRIPTION
This PR adds the following sections to the Sunrise Choir implementation page:

- Introduction: various repo and documentation links
- SSB-Keyfile: how to generate, read and write keys
  - Signing: how to sign an object and create a Message
  - Verification: how to verify the fields and signature of a signed object
- Cryptography: background and links for cryptographic code and documentation
  - Verification: how to verify the signature of an entire ssb message (or collection of messages)
  - Validation: how to validate a message hash chain or feed hash chain (collection of messages)
- TODO
- Contact: contact details for the developers and documentor

I have also created a playground repo containing the code examples from the docs: [sunrise-ssb-playground](https://github.com/mycognosist/sunrise-ssb-playground). I find it's often nice to have actual executable code when learning to navigate and use a new library.