### PR TITLE
add golang example snippets

### DIFF
--- a/docs/golang/README.md
+++ b/docs/golang/README.md
@@ -236,55 +236,6 @@ func TestAnExampleFunction (t *testing) {
   // use stuff like r.Equal(..) or r.NoError(...) to your hearts cotent
 ```
 
-#### Signing an announcement with the root metafeed's key
-```golang
-announcement := legacy.NewMetafeedAnnounce(kpMetafeed.ID(), kpMain.ID())
-signedAnnouncement, err := announcement.Sign(kpMetafeed.PrivateKey, nil)
-r.NoError(err)
-```
-
-
-#### Verify mf announcement is correct
-```golang
-_, ok := legacy.VerifyMetafeedAnnounce(signedMsg, theUpgradingOne.ID(), &hmacSecret)
-r.True(ok, "verify failed")
-```
-
-
-#### Creating an announcement message
-```golang
-ma := legacy.NewMetafeedAnnounce(bot.KeyPair.ID(), subfeed)
-
-signedMsg, err := ma.Sign(bot.KeyPair.Secret(), nil)
-r.NoError(err)
-
-ref, err := bot.MetaFeeds.Publish(subfeed, signedMsg)
-r.NoError(err)
-
-msg, err := bot.Get(ref)
-r.NoError(err)
-t.Log("content:", string(msg.ContentBytes()))
-
-mm, ok := msg.(*multimsg.MultiMessage)
-r.True(ok, "wrong type: %T", msg)
-
-lm, ok := mm.AsLegacy()
-r.True(ok)
-```
-
-#### Add a main feed to the metafeed `metafeed/add/existing`
-```golang
-mfAddExisting := metamngmt.NewAddExistingMessage(kpMetafeed.ID(), kpMain.ID(), "main")
-mfAddExisting.Tangles["metafeed"] = refs.TanglePoint{Root: nil, Previous: nil}
-
-// sign the bendybutt message with mf.Secret + main.Secret
-signedAddExistingContent, err := metafeed.SubSignContent(kpMain.Secret(), mfAddExisting)
-if err != nil {
-	return err
-}
-mf.publish.Append(signedAddExistingContent)
-```
-
 #### Register indexes (and then get them)
 ```golang
 err = bot.MetaFeeds.RegisterIndex(mfId, mainFeedRef, "about")

--- a/docs/golang/README.md
+++ b/docs/golang/README.md
@@ -226,13 +226,14 @@ incomplete snippets, aimed at helping get developers over conceptuals bumps by d
 the gist of a task without creating a full on example program.
 
 **Note**: Some of the snippets below are demonstrating the expected behaviour using the assertion package
-`testify`:
+[testify](https://pkg.go.dev/github.com/stretchr/testify/require):
 
 ```golang
 import `github.com/stretchr/testify/require`
 // ...
-func TestAnExampleFunction (t *testing)
-r := require.New(t)
+func TestAnExampleFunction (t *testing) {
+  r := require.New(t)
+  // use stuff like r.Equal(..) or r.NoError(...) to your hearts cotent
 ```
 
 #### Signing an announcement with the root metafeed's key

--- a/docs/golang/README.md
+++ b/docs/golang/README.md
@@ -284,17 +284,6 @@ if err != nil {
 mf.publish.Append(signedAddExistingContent)
 ```
 
-#### Get a feed using a feedref
-```golang
-var createGetFeed = func(bot *Sbot) func(feedId refs.FeedRef) margaret.Log {
-	return func(feedId refs.FeedRef) margaret.Log {
-		feed, err := bot.Users.Get(storedrefs.Feed(feedId))
-		r.NoError(err)
-		return feed
-	}
-}
-```
-
 #### Register indexes (and then get them)
 ```golang
 err = bot.MetaFeeds.RegisterIndex(mfId, mainFeedRef, "about")
@@ -315,6 +304,85 @@ contactIndex := getFeed(contactIndexId)
 checkSeq(contactIndex, int(margaret.SeqEmpty))
 ```
 
+#### Get a feed using a feedref
+```golang
+func getFeed(bot *sbot.Sbot, feedID refs.FeedRef) (margaret.Log, error) {
+	feed, err := bot.Users.Get(storedrefs.Feed(feedID))
+	if err != nil {
+		return nil, fmt.Errorf("get feed failed", err)
+	}
+
+	// convert from log of seqnos-in-rxlog to log of refs.Message and return
+	return mutil.Indirect(bot.ReceiveLog, feed), nil
+}
+```
+
+#### Debug print an entire log using its feedref
+```golang
+// error wrap - a helper util
+// string header will be prefixed before each message. typically it is the context we're generating errors within.
+// msg is the specific message, err is the error (if passed)
+func ew(header string) func(msg string, err ...error) error {
+	return func(msg string, err ...error) error {
+		if len(err) > 0 {
+			return fmt.Errorf("[gossb: %s] %s (%w)", header, msg, err[0])
+		}
+		return fmt.Errorf("[gossb: %s] %s", header, msg)
+	}
+}
+
+func printLog(bot *sbot.Sbot, feedid refs.FeedRef) error {
+	e := ew("print log")
+
+	l, err := getFeed(bot, feedid)
+	if err != nil {
+		return e(fmt.Sprintf("couldnt get log %s", feedid.ShortSigil()), err)
+	}
+
+	src, err := l.Query()
+	if err != nil {
+		return e("failed to query log", err)
+	}
+
+	seq := l.Seq()
+	i := int64(0)
+	inform("last seqno:", seq)
+
+	for {
+		v, err := src.Next(context.TODO())
+		if luigi.IsEOS(err) {
+			break
+		}
+		inform("value:", v)
+		mm, ok := v.(refs.Message)
+		if !ok {
+			return e(fmt.Sprintf("expected %T to be a refs.Message (wrong log type? missing indirection to receive log?)", v))
+		}
+
+		fmt.Printf("log seq: %d - %s:%d (%s)\n",
+			i,
+			mm.Author().ShortSigil(),
+			mm.Seq(),
+			mm.Key().ShortSigil())
+
+		b := mm.ContentBytes()
+		if n := len(b); n > 128 {
+			fmt.Println("truncating", n, " to last 32 bytes")
+			b = b[len(b)-32:]
+		}
+		fmt.Printf("\n%s\n", hex.Dump(b))
+
+		i++
+	}
+
+	// margaret is 0-indexed
+	seq++
+	if seq != i {
+		return e(fmt.Sprintf("seq differs from iterated count: %d vs %d", seq, i))
+	}
+	return nil
+}
+```
 
 ## Links
 


### PR DESCRIPTION
When creating the go-ssb metafeed migration util (https://github.com/cryptoscope/ssb/pull/120) I collected a bunch of useful snippets for accomplishing the main tasks I needed to do. 

Some of them are more generally useful, others kind of show how you can accomplish some tasks when making go-ssb function calls.