### PR TITLE
update links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ If you'd like an erotic representation of the Secret Handshake Protocol, you can
 - [dev.scuttlebutt.nz](https://dev.scuttlebutt.nz) ([sources](https://github.com/ssbc/dev.scuttlebutt.nz))
 - [handbook.scuttlebutt.nz](https://handbook.scuttlebutt.nz) ([sources](https://github.com/ssbc/handbook.scuttlebutt.nz))
 - [scuttlebot.io](https://scuttlebot.io) ([sources](https://git.scuttlebot.io/%25hg8wG6xCDKVWoPYCS84HY7Adrd6JEUYoM23%2BGwn24I4%3D.sha256) (`git-ssb`))
-- [scuttlebutt.eu](https://scuttlebutt.eu) ([sources](https://github.com/scuttlebutt-eu/scuttlebutt-eu.github.io))
+- [scuttlebutt.eu (defunct)](https://github.com/scuttlebutt-eu/important-documents)
 - [scuttlebutt.nz](https://scuttlebutt.nz) ([sources](https://gitlab.com/ssbc/scuttlebutt.nz))
 - [ssbc.github.io](https://ssbc.github.io) ([sources](https://github.com/ssbc/ssbc.github.io))
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Language               | Name | Status | In production
 [Node.js](javascript/) | N/A, see [SSBC](https://github.com/orgs/ssbc/repositories?language=javascript&type=all) | Stable | ✓ 
 [Go](golang/)          | [`go-ssb`](https://github.com/ssbc/go-ssb) | Alpha | ✓
 [Go](golang/)          | [`scuttlego`](https://github.com/planetary-social/scuttlego) | Alpha (?) | ?
-[Rust](rust/)          | N/A, see [Kuska-SSB](https://github.com/Kuska-ssb) | Pre-alpha (?) | ?
+[Rust](rust/)          | [`solar`](https://github.com/mycognosist/solar) | Alpha (?) | ?
 [Python](python/)      | [`pyssb`](https://github.com/pferreir/pyssb) | Pre-alpha (?) | No
 
 ## Learn some core ideas


### PR DESCRIPTION
since i linked someone the dev portal i figured i'd put in a pr with some updated links! regardless of the future of things, i reckon it's useful if the current site is kept up to date. more concretely:

* ssb eu is defunct, so i removed that website and replaced it with a link to the documents repo of the [ssb eu org](https://github.com/scuttlebutt-eu)
* [glyph's solar repo](https://github.com/mycognosist/solar) has had significant work (457 additional commits, yowza!) compared to the linked [kuska-ssb org](https://github.com/Kuska-ssb) (also defunct), so for rust i've linked to solar instead. you can still find kuska-ssb by the fact that solar is visibly forked from there